### PR TITLE
Implement notes page and basic navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider, useAuth } from './hooks/useAuth';
 import { AuthPage } from './pages/AuthPage';
 import { Dashboard } from './pages/Dashboard';
 import { BookView } from './pages/BookView';
+import { NotesPage } from './pages/NotesPage';
 import { Layout } from './components/Layout';
 import { Sidebar } from './components/Sidebar';
 import { Book } from './types';
@@ -33,10 +34,10 @@ function AppContent() {
       <div className="flex-1 flex flex-col">
         <Layout>
           {activeTab === 'dashboard' && (
-            <Dashboard />
+            <Dashboard onSelectBook={setSelectedBook} />
           )}
           {activeTab === 'books' && (
-            <Dashboard />
+            <Dashboard onSelectBook={setSelectedBook} />
           )}
           {activeTab === 'statistics' && (
             <div className="text-center py-12">
@@ -61,6 +62,9 @@ function AppContent() {
               <h2 className="text-2xl font-bold text-gray-900 mb-4">Objets</h2>
               <p className="text-gray-600">Vue globale des objets en cours de développement</p>
             </div>
+          )}
+          {activeTab === 'notes' && (
+            <NotesPage />
           )}
           {activeTab === 'settings' && (
             <div className="text-center py-12">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Home, Book, BarChart3, Users, MapPin, Package, Settings } from 'lucide-react';
+import { Home, Book, BarChart3, Users, MapPin, Package, Settings, StickyNote } from 'lucide-react';
 
 interface SidebarProps {
   activeTab?: string;
@@ -13,6 +13,7 @@ const navigation = [
   { id: 'characters', name: 'Personnages', icon: Users },
   { id: 'locations', name: 'Lieux', icon: MapPin },
   { id: 'objects', name: 'Objets', icon: Package },
+  { id: 'notes', name: 'Bloc-notes', icon: StickyNote },
   { id: 'settings', name: 'Paramètres', icon: Settings },
 ];
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,11 +8,10 @@ import { ProgressBar } from '../components/ProgressBar';
 import { Book } from '../types';
 import { calculateProgress, formatWordCount } from '../utils/wordCount';
 
-export function Dashboard() {
+export function Dashboard({ onSelectBook }: { onSelectBook?: (book: Book) => void }) {
   const { books, createBook, deleteBook } = useBooks();
   const { user } = useAuth();
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
   const [newBookData, setNewBookData] = useState({
     title: '',
     genre: '',
@@ -169,7 +168,7 @@ export function Dashboard() {
               <BookCard
                 key={book.id}
                 book={book}
-                onClick={() => setSelectedBook(book)}
+                onClick={() => onSelectBook?.(book)}
                 onEdit={() => {/* TODO: Open edit modal */}}
                 onDelete={() => handleDeleteBook(book.id)}
               />

--- a/src/pages/NotesPage.tsx
+++ b/src/pages/NotesPage.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { TextEditor } from '../components/TextEditor';
+
+export function NotesPage() {
+  const [note, setNote] = useLocalStorage<string>('quick-note', '');
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = () => {
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1000);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold text-gray-900">Bloc-notes</h2>
+      <TextEditor
+        content={note}
+        onChange={setNote}
+        onSave={handleSave}
+        placeholder="Ecrivez vos idées ici..."
+      />
+      {saved && (
+        <p className="text-sm text-green-600">Note sauvegardée !</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wire dashboard navigation to book view by passing `onSelectBook`
- add a Bloc‑notes page to quickly jot down ideas
- update the sidebar with a new entry for notes

## Testing
- `npm run lint` *(fails: cannot find ESLint packages)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1528ecc88323814f1b02e4cf6046