### PR TITLE
Fix TypeScript dashboard props

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,7 +8,17 @@ import { ProgressBar } from '../components/ProgressBar';
 import { Book } from '../types';
 import { calculateProgress, formatWordCount } from '../utils/wordCount';
 
-export function Dashboard() {
+interface DashboardProps {
+  /**
+   * Optional project information. Some consumers of this component
+   * pass a `project` or `projectId` prop. Typing these props avoids
+   * TypeScript errors without affecting existing behaviour.
+   */
+  project?: unknown;
+  projectId?: string;
+}
+
+export function Dashboard({ project, projectId }: DashboardProps) {
   const { books, createBook, deleteBook } = useBooks();
   const { user } = useAuth();
   const [showCreateModal, setShowCreateModal] = useState(false);


### PR DESCRIPTION
## Summary
- allow Dashboard to receive optional project props

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find type definition file for 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684a16423f08832390d8fae2cc7c1ff8